### PR TITLE
Eclipse 2022-12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,16 @@
-.class
+# Maven
+target/
+*.releaseBackup
+release.properties
+
+# Eclipse
 .classpath
 .project
 .settings
-target/
-*/*.iml
+
+# IntelliJ IDEA
 *.iml
-*.releaseBackup
-release.properties
+.idea/
+
+# Other
+.class

--- a/catalog.xml
+++ b/catalog.xml
@@ -10,7 +10,7 @@
       <name>AspectJ</name>
       <provider>SpringSource</provider>
       <p2>
-        <repositoryUrl>http://dist.springsource.org/release/AJDT/composite/</repositoryUrl>
+        <repositoryUrl>https://dist.springsource.org/release/AJDT/composite/</repositoryUrl>
         <iuId>org.maven.ide.eclipse.ajdt.feature.feature.group</iuId>
         <iuVersion>0.13.0.201107281640</iuVersion>
         <lifecycleMappingIU>
@@ -19,7 +19,7 @@
       </p2>
       <overview>
         <summary>Maven Integration for AspectJ Development Tools</summary>
-        <url>http://eclipse.org/ajdt</url>
+        <url>https://eclipse.org/ajdt</url>
       </overview>
     </catalogItem>
   </catalogItems>

--- a/org.maven.ide.eclipse.ajdt.feature/feature.properties
+++ b/org.maven.ide.eclipse.ajdt.feature/feature.properties
@@ -3,7 +3,7 @@
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
+# https://www.eclipse.org/legal/epl-v10.html
 # 
 # Contributors:
 #     IBM Corporation - initial API and implementation
@@ -13,7 +13,7 @@ featureName=Maven Integration for AJDT (Optional)
 providerName=Sonatype, Inc.
 
 description=Maven project configuration for Eclipse AJDT
-descriptionURL=http://m2eclipse.sonatype.org
+descriptionURL=https://m2eclipse.sonatype.org
 
 licenseURL=license.html
 
@@ -40,7 +40,7 @@ Applicable Licenses\n\
 Unless otherwise indicated, all Content made available by the Eclipse Foundation\n\
 is provided to you under the terms and conditions of the Eclipse Public\n\
 License Version 1.0 ("EPL"). A copy of the EPL is provided with this\n\
-Content and is also available at http://www.eclipse.org/legal/epl-v10.html.\n\
+Content and is also available at https://www.eclipse.org/legal/epl-v10.html.\n\
 For purposes of the EPL, "Program" will mean the Content.\n\
 \n\
 Content includes, but is not limited to, source code, object code,\n\
@@ -92,12 +92,12 @@ THE ABOUTS, FEATURE LICENSES AND FEATURE UPDATE LICENSES MAY REFER\n\
 TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS.\n\
 SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
-    - Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
-    - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-    - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
-    - IBM Public License 1.0 (available at http://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
-    - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
-    - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\
+    - Common Public License Version 1.0 (available at https://www.eclipse.org/legal/cpl-v10.html)\n\
+    - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+    - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
+    - IBM Public License 1.0 (available at https://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
+    - Metro Link Public License 1.00 (available at https://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
+    - Mozilla Public License Version 1.1 (available at https://www.mozilla.org/MPL/MPL-1.1.html)\n\
 \n\
 IT IS YOUR OBLIGATION TO READ AND ACCEPT ALL SUCH TERMS AND CONDITIONS PRIOR\n\
 TO USE OF THE CONTENT. If no About, Feature License or Feature Update License\n\
@@ -117,4 +117,4 @@ Java and all Java-based trademarks are trademarks of Sun Microsystems, Inc. in t
 ########### end of license property ##########################################
 
 copyright=Copyright (c) 2008 Sonatype, Inc.
-copyrightUrl=http://sonatype.com/
+copyrightUrl=https://sonatype.com/

--- a/org.maven.ide.eclipse.ajdt.feature/license.html
+++ b/org.maven.ide.eclipse.ajdt.feature/license.html
@@ -14,20 +14,20 @@
    OF THE CONTENT IS GOVERNED BY THIS AGREEMENT AND/OR THE TERMS AND CONDITIONS OF ANY APPLICABLE LICENSE AGREEMENTS OR
    NOTICES INDICATED OR REFERENCED BELOW.  IF YOU DO NOT AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT AND THE TERMS AND
    CONDITIONS OF ANY APPLICABLE LICENSE AGREEMENTS OR NOTICES INDICATED OR REFERENCED BELOW, THEN YOU MAY NOT USE THE CONTENT.</p>
-   
-<h3>Applicable Licenses</h3>   
-   
+
+<h3>Applicable Licenses</h3>
+
 <p>Unless otherwise indicated, all Content made available by the
 Eclipse Foundation is provided to you under the terms and conditions of
 the Eclipse Public License Version 1.0 ("EPL"). A copy of the EPL is
-provided with this Content and is also available at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+provided with this Content and is also available at <a href="https://www.eclipse.org/legal/epl-v10.html">https://www.eclipse.org/legal/epl-v10.html</a>.
    For purposes of the EPL, "Program" will mean the Content.</p>
 
 <p>Content includes, but is not limited to, source code, object code,
 documentation and other files maintained in the Eclipse.org CVS
 repository ("Repository") in CVS modules ("Modules") and made available
 as downloadable archives ("Downloads").</p>
-   
+
 <ul>
 	<li>Content may be structured and packaged into modules to
 facilitate delivering, extending, and upgrading the Content. Typical
@@ -44,8 +44,8 @@ the Plug-ins and/or Fragments associated with that Feature.</li>
 may also include other Features ("Included Features"). Within a
 Feature, files named "feature.xml" may contain a list of the names and
 version numbers of Included Features.</li>
-</ul>   
- 
+</ul>
+
 <p>The terms and conditions governing Plug-ins and Fragments should be
 contained in files named "about.html" ("Abouts"). The terms and
 conditions governing Features and
@@ -61,7 +61,7 @@ including, but not limited to the following locations:</p>
 	<li>Sub-directories of the directory named "src" of certain Plug-ins</li>
 	<li>Feature directories</li>
 </ul>
-		
+
 <p>Note: if a Feature made available by the Eclipse Foundation is
 installed using the Eclipse Update Manager, you must agree to a license
 ("Feature Update License") during the
@@ -82,12 +82,12 @@ CONDITIONS. SOME OF THESE
 OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):</p>
 
 <ul>
-	<li>Common Public License Version 1.0 (available at <a href="http://www.eclipse.org/legal/cpl-v10.html">http://www.eclipse.org/legal/cpl-v10.html</a>)</li>
-	<li>Apache Software License 1.1 (available at <a href="http://www.apache.org/licenses/LICENSE">http://www.apache.org/licenses/LICENSE</a>)</li>
-	<li>Apache Software License 2.0 (available at <a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a>)</li>
-	<li>IBM Public License 1.0 (available at <a href="http://oss.software.ibm.com/developerworks/opensource/license10.html">http://oss.software.ibm.com/developerworks/opensource/license10.html</a>)</li>	
-	<li>Metro Link Public License 1.00 (available at <a href="http://www.opengroup.org/openmotif/supporters/metrolink/license.html">http://www.opengroup.org/openmotif/supporters/metrolink/license.html</a>)</li>
-	<li>Mozilla Public License Version 1.1 (available at <a href="http://www.mozilla.org/MPL/MPL-1.1.html">http://www.mozilla.org/MPL/MPL-1.1.html</a>)</li>
+	<li>Common Public License Version 1.0 (available at <a href="https://www.eclipse.org/legal/cpl-v10.html">https://www.eclipse.org/legal/cpl-v10.html</a>)</li>
+	<li>Apache Software License 1.1 (available at <a href="https://www.apache.org/licenses/LICENSE">https://www.apache.org/licenses/LICENSE</a>)</li>
+	<li>Apache Software License 2.0 (available at <a href="https://www.apache.org/licenses/LICENSE-2.0">https://www.apache.org/licenses/LICENSE-2.0</a>)</li>
+	<li>IBM Public License 1.0 (available at <a href="https://oss.software.ibm.com/developerworks/opensource/license10.html">https://oss.software.ibm.com/developerworks/opensource/license10.html</a>)</li>
+	<li>Metro Link Public License 1.00 (available at <a href="https://www.opengroup.org/openmotif/supporters/metrolink/license.html">https://www.opengroup.org/openmotif/supporters/metrolink/license.html</a>)</li>
+	<li>Mozilla Public License Version 1.1 (available at <a href="https://www.mozilla.org/MPL/MPL-1.1.html">https://www.mozilla.org/MPL/MPL-1.1.html</a>)</li>
 </ul>
 
 <p>IT IS YOUR OBLIGATION TO READ AND ACCEPT ALL SUCH TERMS AND
@@ -104,6 +104,6 @@ and/or re-export to another country, of encryption software. BEFORE
 using any encryption software, please check the country's laws,
 regulations and policies concerning the import, possession, or use, and
 re-export of encryption software, to see if this is permitted.</p>
-   
-<small>Java and all Java-based trademarks are trademarks of Sun Microsystems, Inc. in the United States, other countries, or both.</small>   
+
+<small>Java and all Java-based trademarks are trademarks of Sun Microsystems, Inc. in the United States, other countries, or both.</small>
 </body></html>

--- a/org.maven.ide.eclipse.ajdt.feature/pom.xml
+++ b/org.maven.ide.eclipse.ajdt.feature/pom.xml
@@ -13,11 +13,10 @@
 		<groupId>org.maven.ide.eclipse.ajdt</groupId>
 		<artifactId>org.maven.ide.eclipse.ajdt.parent</artifactId>
 		<version>0.14.5-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>org.maven.ide.eclipse.ajdt.feature</artifactId>
-	
+
 	<packaging>eclipse-feature</packaging>
 
 	<name>Maven Integration for AJDT (Optional)</name>

--- a/org.maven.ide.eclipse.ajdt.feature/pom.xml
+++ b/org.maven.ide.eclipse.ajdt.feature/pom.xml
@@ -4,7 +4,7 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Public License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/legal/epl-v10.html
+  https://www.eclipse.org/legal/epl-v10.html
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/org.maven.ide.eclipse.ajdt.feature/sourceTemplateFeature/feature.properties
+++ b/org.maven.ide.eclipse.ajdt.feature/sourceTemplateFeature/feature.properties
@@ -3,7 +3,7 @@
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
-# http://www.eclipse.org/legal/epl-v10.html
+# https://www.eclipse.org/legal/epl-v10.html
 # 
 # Contributors:
 #     IBM Corporation - initial API and implementation
@@ -13,7 +13,7 @@ featureName=Maven Integration for AJDT Sources (Optional)
 providerName=Sonatype, Inc.
 
 description=This Feature provides the source code for the AJDT Maven project configurator
-descriptionURL=http://m2eclipse.sonatype.org
+descriptionURL=https://m2eclipse.sonatype.org
 
 licenseURL=license.html
 
@@ -40,7 +40,7 @@ Applicable Licenses\n\
 Unless otherwise indicated, all Content made available by the Eclipse Foundation\n\
 is provided to you under the terms and conditions of the Eclipse Public\n\
 License Version 1.0 ("EPL"). A copy of the EPL is provided with this\n\
-Content and is also available at http://www.eclipse.org/legal/epl-v10.html.\n\
+Content and is also available at https://www.eclipse.org/legal/epl-v10.html.\n\
 For purposes of the EPL, "Program" will mean the Content.\n\
 \n\
 Content includes, but is not limited to, source code, object code,\n\
@@ -92,12 +92,12 @@ THE ABOUTS, FEATURE LICENSES AND FEATURE UPDATE LICENSES MAY REFER\n\
 TO THE EPL OR OTHER LICENSE AGREEMENTS, NOTICES OR TERMS AND CONDITIONS.\n\
 SOME OF THESE OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):\n\
 \n\
-    - Common Public License Version 1.0 (available at http://www.eclipse.org/legal/cpl-v10.html)\n\
-    - Apache Software License 1.1 (available at http://www.apache.org/licenses/LICENSE)\n\
-    - Apache Software License 2.0 (available at http://www.apache.org/licenses/LICENSE-2.0)\n\
-    - IBM Public License 1.0 (available at http://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
-    - Metro Link Public License 1.00 (available at http://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
-    - Mozilla Public License Version 1.1 (available at http://www.mozilla.org/MPL/MPL-1.1.html)\n\
+    - Common Public License Version 1.0 (available at https://www.eclipse.org/legal/cpl-v10.html)\n\
+    - Apache Software License 1.1 (available at https://www.apache.org/licenses/LICENSE)\n\
+    - Apache Software License 2.0 (available at https://www.apache.org/licenses/LICENSE-2.0)\n\
+    - IBM Public License 1.0 (available at https://oss.software.ibm.com/developerworks/opensource/license10.html)\n\
+    - Metro Link Public License 1.00 (available at https://www.opengroup.org/openmotif/supporters/metrolink/license.html)\n\
+    - Mozilla Public License Version 1.1 (available at https://www.mozilla.org/MPL/MPL-1.1.html)\n\
 \n\
 IT IS YOUR OBLIGATION TO READ AND ACCEPT ALL SUCH TERMS AND CONDITIONS PRIOR\n\
 TO USE OF THE CONTENT. If no About, Feature License or Feature Update License\n\
@@ -117,4 +117,4 @@ Java and all Java-based trademarks are trademarks of Sun Microsystems, Inc. in t
 ########### end of license property ##########################################
 
 copyright=Copyright (c) 2008 Sonatype, Inc.
-copyrightUrl=http://sonatype.com/
+copyrightUrl=https://sonatype.com/

--- a/org.maven.ide.eclipse.ajdt.feature/sourceTemplateFeature/license.html
+++ b/org.maven.ide.eclipse.ajdt.feature/sourceTemplateFeature/license.html
@@ -14,20 +14,20 @@
    OF THE CONTENT IS GOVERNED BY THIS AGREEMENT AND/OR THE TERMS AND CONDITIONS OF ANY APPLICABLE LICENSE AGREEMENTS OR
    NOTICES INDICATED OR REFERENCED BELOW.  IF YOU DO NOT AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT AND THE TERMS AND
    CONDITIONS OF ANY APPLICABLE LICENSE AGREEMENTS OR NOTICES INDICATED OR REFERENCED BELOW, THEN YOU MAY NOT USE THE CONTENT.</p>
-   
-<h3>Applicable Licenses</h3>   
-   
+
+<h3>Applicable Licenses</h3>
+
 <p>Unless otherwise indicated, all Content made available by the
 Eclipse Foundation is provided to you under the terms and conditions of
 the Eclipse Public License Version 1.0 ("EPL"). A copy of the EPL is
-provided with this Content and is also available at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+provided with this Content and is also available at <a href="https://www.eclipse.org/legal/epl-v10.html">https://www.eclipse.org/legal/epl-v10.html</a>.
    For purposes of the EPL, "Program" will mean the Content.</p>
 
 <p>Content includes, but is not limited to, source code, object code,
 documentation and other files maintained in the Eclipse.org CVS
 repository ("Repository") in CVS modules ("Modules") and made available
 as downloadable archives ("Downloads").</p>
-   
+
 <ul>
 	<li>Content may be structured and packaged into modules to
 facilitate delivering, extending, and upgrading the Content. Typical
@@ -44,8 +44,8 @@ the Plug-ins and/or Fragments associated with that Feature.</li>
 may also include other Features ("Included Features"). Within a
 Feature, files named "feature.xml" may contain a list of the names and
 version numbers of Included Features.</li>
-</ul>   
- 
+</ul>
+
 <p>The terms and conditions governing Plug-ins and Fragments should be
 contained in files named "about.html" ("Abouts"). The terms and
 conditions governing Features and
@@ -61,7 +61,7 @@ including, but not limited to the following locations:</p>
 	<li>Sub-directories of the directory named "src" of certain Plug-ins</li>
 	<li>Feature directories</li>
 </ul>
-		
+
 <p>Note: if a Feature made available by the Eclipse Foundation is
 installed using the Eclipse Update Manager, you must agree to a license
 ("Feature Update License") during the
@@ -82,12 +82,12 @@ CONDITIONS. SOME OF THESE
 OTHER LICENSE AGREEMENTS MAY INCLUDE (BUT ARE NOT LIMITED TO):</p>
 
 <ul>
-	<li>Common Public License Version 1.0 (available at <a href="http://www.eclipse.org/legal/cpl-v10.html">http://www.eclipse.org/legal/cpl-v10.html</a>)</li>
-	<li>Apache Software License 1.1 (available at <a href="http://www.apache.org/licenses/LICENSE">http://www.apache.org/licenses/LICENSE</a>)</li>
-	<li>Apache Software License 2.0 (available at <a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a>)</li>
-	<li>IBM Public License 1.0 (available at <a href="http://oss.software.ibm.com/developerworks/opensource/license10.html">http://oss.software.ibm.com/developerworks/opensource/license10.html</a>)</li>	
-	<li>Metro Link Public License 1.00 (available at <a href="http://www.opengroup.org/openmotif/supporters/metrolink/license.html">http://www.opengroup.org/openmotif/supporters/metrolink/license.html</a>)</li>
-	<li>Mozilla Public License Version 1.1 (available at <a href="http://www.mozilla.org/MPL/MPL-1.1.html">http://www.mozilla.org/MPL/MPL-1.1.html</a>)</li>
+	<li>Common Public License Version 1.0 (available at <a href="https://www.eclipse.org/legal/cpl-v10.html">https://www.eclipse.org/legal/cpl-v10.html</a>)</li>
+	<li>Apache Software License 1.1 (available at <a href="https://www.apache.org/licenses/LICENSE">https://www.apache.org/licenses/LICENSE</a>)</li>
+	<li>Apache Software License 2.0 (available at <a href="https://www.apache.org/licenses/LICENSE-2.0">https://www.apache.org/licenses/LICENSE-2.0</a>)</li>
+	<li>IBM Public License 1.0 (available at <a href="https://oss.software.ibm.com/developerworks/opensource/license10.html">https://oss.software.ibm.com/developerworks/opensource/license10.html</a>)</li>
+	<li>Metro Link Public License 1.00 (available at <a href="https://www.opengroup.org/openmotif/supporters/metrolink/license.html">https://www.opengroup.org/openmotif/supporters/metrolink/license.html</a>)</li>
+	<li>Mozilla Public License Version 1.1 (available at <a href="https://www.mozilla.org/MPL/MPL-1.1.html">https://www.mozilla.org/MPL/MPL-1.1.html</a>)</li>
 </ul>
 
 <p>IT IS YOUR OBLIGATION TO READ AND ACCEPT ALL SUCH TERMS AND
@@ -104,6 +104,6 @@ and/or re-export to another country, of encryption software. BEFORE
 using any encryption software, please check the country's laws,
 regulations and policies concerning the import, possession, or use, and
 re-export of encryption software, to see if this is permitted.</p>
-   
-<small>Java and all Java-based trademarks are trademarks of Sun Microsystems, Inc. in the United States, other countries, or both.</small>   
+
+<small>Java and all Java-based trademarks are trademarks of Sun Microsystems, Inc. in the United States, other countries, or both.</small>
 </body></html>

--- a/org.maven.ide.eclipse.ajdt.site/pom.xml
+++ b/org.maven.ide.eclipse.ajdt.site/pom.xml
@@ -4,18 +4,17 @@
 		<groupId>org.maven.ide.eclipse.ajdt</groupId>
 		<artifactId>org.maven.ide.eclipse.ajdt.parent</artifactId>
 		<version>0.14.5-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
 	</parent>
-	
+
 	<packaging>eclipse-update-site</packaging>
-	
+
 	<groupId>org.maven.ide.eclipse.ajdt.site</groupId>
 	<artifactId>org.maven.ide.eclipse.ajdt.site</artifactId>
 
 	<properties>
 		<dist.accessKey>${accessKey}</dist.accessKey>
 		<dist.secretKey>${secretKey}</dist.secretKey>
-	</properties>  
+	</properties>
 
 	<build>
 		<plugins>
@@ -33,6 +32,11 @@
 				<!-- </execution> -->
 				<!-- </executions> -->
 				<configuration>
+					<!--
+						TODO:
+						  These parameters are from Tycho p2 Metadata Plugin, not from Tycho OSGi Packaging Plugin, see
+						  https://www.eclipse.org/tycho/sitedocs/tycho-p2/tycho-p2-plugin/update-site-p2-metadata-mojo.html
+					-->
 					<metadataRepositoryName>Maven Integration for Eclipse Settings</metadataRepositoryName>
 					<artifactRepositoryName>Maven Integration for Eclipse Settings</artifactRepositoryName>
 				</configuration>

--- a/org.maven.ide.eclipse.ajdt.site/site.xml
+++ b/org.maven.ide.eclipse.ajdt.site/site.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <description url="http://github.com/cheleb/m2e-settings/">
+   <description url="https://github.com/cheleb/m2e-settings/">
       Maven Integration for Eclipse Extras
    </description>
    <feature url="features/org.maven.ide.eclipse.ajdt.feature_0.14.5.qualifier.jar" id="org.maven.ide.eclipse.ajdt.feature" version="0.14.5.qualifier">

--- a/org.maven.ide.eclipse.ajdt.tests/META-INF/MANIFEST.MF
+++ b/org.maven.ide.eclipse.ajdt.tests/META-INF/MANIFEST.MF
@@ -13,13 +13,12 @@ Require-Bundle: org.junit,
  org.eclipse.core.resources,
  org.eclipse.ajdt.core,
  org.eclipse.jdt.core,
- org.eclipse.m2e.core;bundle-version="1.0.0",
- org.eclipse.m2e.tests.common;bundle-version="1.0.0",
- org.eclipse.ajdt.ui;bundle-version="2.0.0",
+ org.eclipse.m2e.core,
+ org.eclipse.m2e.tests.common,
+ org.eclipse.ajdt.ui,
  org.eclipse.ui
 Eclipse-BundleShape: dir
 Import-Package: org.junit;version="4.12.0",
  org.junit.jupiter.api;version="5.0.0",
  org.slf4j,
  org.slf4j.impl
-

--- a/org.maven.ide.eclipse.ajdt.tests/pom.xml
+++ b/org.maven.ide.eclipse.ajdt.tests/pom.xml
@@ -8,20 +8,19 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	
+
 	<parent>
 		<groupId>org.maven.ide.eclipse.ajdt</groupId>
 		<artifactId>org.maven.ide.eclipse.ajdt.parent</artifactId>
 		<version>0.14.5-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
 	</parent>
-	
+
 	<artifactId>org.maven.ide.eclipse.ajdt.tests</artifactId>
-	
+
 	<packaging>eclipse-test-plugin</packaging>
-	
+
 	<name>Maven Integration for Eclipse AJDT tests</name>
-	
+
 	<build>
 		<plugins>
 			<plugin>

--- a/org.maven.ide.eclipse.ajdt.tests/pom.xml
+++ b/org.maven.ide.eclipse.ajdt.tests/pom.xml
@@ -4,7 +4,7 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Public License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/legal/epl-v10.html
+  https://www.eclipse.org/legal/epl-v10.html
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/org.maven.ide.eclipse.ajdt.tests/src/org/maven/ide/eclipse/ajdt/tests/AjdtProjectConfiguratorTest.java
+++ b/org.maven.ide.eclipse.ajdt.tests/src/org/maven/ide/eclipse/ajdt/tests/AjdtProjectConfiguratorTest.java
@@ -113,7 +113,11 @@ public class AjdtProjectConfiguratorTest extends AbstractMavenProjectTestCase {
     String[] aspectPath = AspectJCorePreferences.getResolvedProjectAspectPath(project);
     assertEquals("The result of getResolvedProjectAspectPath is always an array of length 3", 3, aspectPath.length);
     assertTrue(aspectPath[0], aspectPath[0].contains("/maven-core-"));
-    assertEquals("Should be one segment of this aspect path", aspectPath[0].length()-1, aspectPath[0].indexOf(':'));
+    assertEquals(
+      "Should be one segment of this aspect path",
+      aspectPath[0].length()-1,
+      aspectPath[0].indexOf(System.getProperty("path.separator"))
+    );
     assertTrue("Content kind should be BINARY",aspectPath[1].startsWith("2")); //$NON-NLS-1$ //$NON-NLS-2$
     assertTrue("Entry kind should be LIBRARY", aspectPath[2].startsWith("1")); //$NON-NLS-1$ //$NON-NLS-2$
   }
@@ -139,7 +143,11 @@ public class AjdtProjectConfiguratorTest extends AbstractMavenProjectTestCase {
     String[] aspectPath = AspectJCorePreferences.getResolvedProjectAspectPath(project);
     assertEquals("The result of getResolvedProjectAspectPath is always an array of length 3", 3, aspectPath.length);
     assertTrue(aspectPath[0].contains("/maven-core-"));
-    assertEquals("Should be one segment of this aspect path", aspectPath[0].length()-1, aspectPath[0].indexOf(':'));
+    assertEquals(
+      "Should be one segment of this aspect path",
+      aspectPath[0].length()-1,
+      aspectPath[0].indexOf(System.getProperty("path.separator"))
+    );
     assertTrue("Content kind should be BINARY",aspectPath[1].startsWith("2")); //$NON-NLS-1$ //$NON-NLS-2$
     assertTrue("Entry kind should be LIBRARY", aspectPath[2].startsWith("1")); //$NON-NLS-1$ //$NON-NLS-2$
   }

--- a/org.maven.ide.eclipse.ajdt.tests/src/org/maven/ide/eclipse/ajdt/tests/AjdtProjectConfiguratorTest.java
+++ b/org.maven.ide.eclipse.ajdt.tests/src/org/maven/ide/eclipse/ajdt/tests/AjdtProjectConfiguratorTest.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *******************************************************************************/
 
 package org.maven.ide.eclipse.ajdt.tests;

--- a/org.maven.ide.eclipse.ajdt/META-INF/MANIFEST.MF
+++ b/org.maven.ide.eclipse.ajdt/META-INF/MANIFEST.MF
@@ -9,9 +9,9 @@ Require-Bundle: org.eclipse.ajdt.core;bundle-version="2.0.0",
  org.eclipse.jdt.core,
  org.eclipse.core.runtime,
  org.eclipse.core.resources,
- org.eclipse.m2e.core;bundle-version="1.0.0",
- org.eclipse.m2e.maven.runtime;bundle-version="1.0.0",
- org.eclipse.m2e.jdt;bundle-version="1.0.0",
- org.slf4j.api;bundle-version="1.6.1"
+ org.eclipse.m2e.core,
+ org.eclipse.m2e.maven.runtime,
+ org.eclipse.m2e.jdt
+Import-Package: org.slf4j
 Bundle-Vendor: Sonatype, Inc.
 Export-Package: org.maven.ide.eclipse.ajdt

--- a/org.maven.ide.eclipse.ajdt/plugin.xml
+++ b/org.maven.ide.eclipse.ajdt/plugin.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin>
-   <extension
-         point="org.eclipse.m2e.core.lifecycleMappingMetadataSource">
+   <extension point="org.eclipse.m2e.core.lifecycleMappingMetadataSource">
    </extension>
-   <extension
-         point="org.eclipse.m2e.core.projectConfigurators">
+   <extension point="org.eclipse.m2e.core.projectConfigurators">
       <configurator
             class="org.maven.ide.eclipse.ajdt.AjdtProjectConfigurator:1"
             id="org.maven.ide.eclipse.ajdt.configurator"

--- a/org.maven.ide.eclipse.ajdt/pom.xml
+++ b/org.maven.ide.eclipse.ajdt/pom.xml
@@ -13,11 +13,10 @@
     <groupId>org.maven.ide.eclipse.ajdt</groupId>
     <artifactId>org.maven.ide.eclipse.ajdt.parent</artifactId>
     <version>0.14.5-SNAPSHOT</version>
-	<relativePath>../pom.xml</relativePath>
   </parent>
 
   <artifactId>org.maven.ide.eclipse.ajdt</artifactId>
-  
+
   <packaging>eclipse-plugin</packaging>
 
   <name>Maven Integration for Eclipse AJDT</name>

--- a/org.maven.ide.eclipse.ajdt/pom.xml
+++ b/org.maven.ide.eclipse.ajdt/pom.xml
@@ -4,7 +4,7 @@
   All rights reserved. This program and the accompanying materials
   are made available under the terms of the Eclipse Public License v1.0
   which accompanies this distribution, and is available at
-  http://www.eclipse.org/legal/epl-v10.html
+  https://www.eclipse.org/legal/epl-v10.html
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>

--- a/org.maven.ide.eclipse.ajdt/src/org/maven/ide/eclipse/ajdt/AjdtProjectConfigurator.java
+++ b/org.maven.ide.eclipse.ajdt/src/org/maven/ide/eclipse/ajdt/AjdtProjectConfigurator.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *******************************************************************************/
 
 package org.maven.ide.eclipse.ajdt;

--- a/org.maven.ide.eclipse.ajdt/src/org/maven/ide/eclipse/ajdt/AspectJPluginConfiguration.java
+++ b/org.maven.ide.eclipse.ajdt/src/org/maven/ide/eclipse/ajdt/AspectJPluginConfiguration.java
@@ -3,7 +3,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
- * http://www.eclipse.org/legal/epl-v10.html
+ * https://www.eclipse.org/legal/epl-v10.html
  *******************************************************************************/
 
 package org.maven.ide.eclipse.ajdt;
@@ -51,7 +51,7 @@ import org.slf4j.LoggerFactory;
    &lt;/plugin&gt;
  * </pre>
  *
- * @see "http://mojo.codehaus.org/aspectj-maven-plugin/compile-mojo.html"
+ * @see "https://mojo.codehaus.org/aspectj-maven-plugin/compile-mojo.html"
  * @author Igor Fedorenko
  * @author Eugene Kuleshov
  */

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <!-- Copyright (c) 2008 Sonatype, Inc. All rights reserved. This program
 	and the accompanying materials are made available under the terms of the
 	Eclipse Public License v1.0 which accompanies this distribution, and is available
-	at http://www.eclipse.org/legal/epl-v10.html -->
+	at https://www.eclipse.org/legal/epl-v10.html -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
@@ -41,12 +41,12 @@
 		<pluginRepository>
 			<id>spring-maven-release</id>
 			<name>Spring Maven Release Repository</name>
-			<url>http://maven.springframework.org/release</url>
+			<url>https://maven.springframework.org/release</url>
 		</pluginRepository>
 		<pluginRepository>
 			<id>springsource-maven-release</id>
 			<name>SpringSource Maven Release Repository</name>
-			<url>http://repository.springsource.com/maven/bundles/release</url>
+			<url>https://repository.springsource.com/maven/bundles/release</url>
 		</pluginRepository>
 	</pluginRepositories>
 
@@ -59,7 +59,7 @@
 		<tycho-version>2.2.0</tycho-version>
 		<!-- <m2eclipse-core.version>0.10.2.20100623-1649</m2eclipse-core.version> -->
 		<!-- <m2eclipse-core.site>0.10.2/S/${m2eclipse-core.version}</m2eclipse-core.site> -->
-		<!-- <m2e.site-compressed>http://repository.sonatype.org/service/local/repositories/forge-sites/content-compressed/</m2e.site-compressed> -->
+		<!-- <m2e.site-compressed>https://repository.sonatype.org/service/local/repositories/forge-sites/content-compressed/</m2e.site-compressed> -->
 
 		<!-- Signing -->
 		<signing.skip>true</signing.skip>
@@ -162,7 +162,7 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.8.1</version>
 				<configuration>
-					<!-- http://maven.apache.org/plugins/maven-compiler-plugin/ -->
+					<!-- https://maven.apache.org/plugins/maven-compiler-plugin/ -->
 					<source>1.11</source>
 					<target>1.11</target>
 					<release>11</release>
@@ -203,7 +203,7 @@
 			<activation>
 				<property>
 					<name>java.vendor.url</name>
-					<value>http://java.sun.com/</value>
+					<value>https://java.sun.com/</value>
 				</property>
 			</activation>
 			<properties>
@@ -215,7 +215,7 @@
 			<activation>
 				<property>
 					<name>java.vendor.url</name>
-					<value>http://www.apple.com/</value>
+					<value>https://www.apple.com/</value>
 				</property>
 			</activation>
 			<properties>

--- a/pom.xml
+++ b/pom.xml
@@ -20,9 +20,9 @@
 			<url>https://repository.sonatype.org/content/groups/sonatype-public-grid</url>
 		</repository>
 		<repository>
-			<id>eclipse-2021-03</id>
+			<id>eclipse-2022-12</id>
 			<layout>p2</layout>
-			<url>https://download.eclipse.org/releases/2021-03</url>
+			<url>https://download.eclipse.org/releases/2022-12</url>
 		</repository>
 		<repository>
 			<id>m2e</id>
@@ -32,7 +32,7 @@
 		<repository>
 			<id>ajdt</id>
 			<layout>p2</layout>
-			<url>https://aspectj.dev/eclipse/ajdt/419</url>
+			<url>https://download.eclipse.org/tools/ajdt/426/dev/update</url>
 		</repository>
 	</repositories>
 
@@ -56,7 +56,7 @@
   </scm>
 
 	<properties>
-		<tycho-version>2.2.0</tycho-version>
+		<tycho-version>2.7.5</tycho-version>
 		<!-- <m2eclipse-core.version>0.10.2.20100623-1649</m2eclipse-core.version> -->
 		<!-- <m2eclipse-core.site>0.10.2/S/${m2eclipse-core.version}</m2eclipse-core.site> -->
 		<!-- <m2e.site-compressed>https://repository.sonatype.org/service/local/repositories/forge-sites/content-compressed/</m2e.site-compressed> -->
@@ -163,9 +163,9 @@
 				<version>3.8.1</version>
 				<configuration>
 					<!-- https://maven.apache.org/plugins/maven-compiler-plugin/ -->
-					<source>1.11</source>
-					<target>1.11</target>
-					<release>11</release>
+					<source>17</source>
+					<target>17</target>
+					<release>17</release>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright (c) 2008 Sonatype, Inc. All rights reserved. This program 
-	and the accompanying materials are made available under the terms of the 
-	Eclipse Public License v1.0 which accompanies this distribution, and is available 
+<!-- Copyright (c) 2008 Sonatype, Inc. All rights reserved. This program
+	and the accompanying materials are made available under the terms of the
+	Eclipse Public License v1.0 which accompanies this distribution, and is available
 	at http://www.eclipse.org/legal/epl-v10.html -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
@@ -17,12 +17,12 @@
 	<repositories>
 		<repository>
 			<id>rso</id>
-			<url>http://repository.sonatype.org/content/groups/sonatype-public-grid</url>
+			<url>https://repository.sonatype.org/content/groups/sonatype-public-grid</url>
 		</repository>
 		<repository>
-			<id>eclipse-2020-12</id>
+			<id>eclipse-2021-03</id>
 			<layout>p2</layout>
-			<url>http://download.eclipse.org/releases/2020-12</url>
+			<url>https://download.eclipse.org/releases/2021-03</url>
 		</repository>
 		<repository>
 			<id>m2e</id>
@@ -32,7 +32,7 @@
 		<repository>
 			<id>ajdt</id>
 			<layout>p2</layout>
-			<url>https://download.eclipse.org/tools/ajdt/410/dev/update</url>
+			<url>https://aspectj.dev/eclipse/ajdt/419</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
I made the project build with the new M2E API used in 2022-12. It also depends on an AJDT version which, in combination with the changes here, fixes #3.

Please take a look at the to-do I commented on. There might be one methods which might not be called anymore, because it does not override a super type method anymore. Please help to make sure that we do not lose any important functionality. I really do not know anything about M2E and this extension. I hope you know more.

Last but not least, please create a new update site for 2022-12, which then I can list in the AspectJ [IDE guide](https://github.com/eclipse/org.aspectj/blob/master/docs/developer/IDE.md#maven-to-eclipse-m2e-connector). For now, I have created a temporary update site https://aspectj.dev/eclipse/m2eclipse-ajdt/eclipse-2022-12/.